### PR TITLE
Fix transforming function calls as values

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -5,7 +5,7 @@ describe('refract', () => {
   it('should generate the schema', () => {
     const { schema: prisma } = codegen({
       datasource: {
-        url: 'secret-url',
+        url: 'env("DATABASE_URL")',
         provider: 'postgresql',
         shadowDatabaseUrl: 'secret-shadow-url',
         referentialIntegrity: 'prisma',

--- a/src/codegen/transform.ts
+++ b/src/codegen/transform.ts
@@ -25,7 +25,8 @@ export const kv = (properties: Properties): string => {
 export const transform = (value: Properties[string]): string => {
   switch (typeof value) {
     case 'string': {
-      if (value.endsWith('()')) return value;
+      // Test if it matches a function call
+      if (/^.*\(.*\)$/.test(value)) return value;
 
       return `"${value}"`;
     }


### PR DESCRIPTION
This fix will add support to passing `env("...")` as a value to the data source URL attribute.