### PR TITLE
Split align method into alignKv and alignFields

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.23",
     "jest": "^27.5.1",
+    "prettier": "^2.6.2",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.3"

--- a/src/codegen/align.ts
+++ b/src/codegen/align.ts
@@ -1,6 +1,7 @@
-// Aligns contents of a model/generator to that of the longest column
-export const align = (value: string, delimiter: string = ' '): string => {
+// Align contents of a datasource/generator to that of the longest column
+export const alignKv = (value: string): string => {
   const lines = value.split('\n');
+  const delimiter = '=';
 
   const max =
     Math.max(...lines.map(l => l.trim().split(delimiter).shift().length)) + 1;
@@ -9,6 +10,30 @@ export const align = (value: string, delimiter: string = ' '): string => {
     .map(line => line.split(delimiter))
     .map(([head, ...rest]) =>
       [head.padEnd(max), delimiter, ...rest.map(v => v.trim())].join(' '),
+    )
+    .join('\n');
+};
+
+// Align contents of a model to that of the longest column
+export const alignFields = (value: string): string => {
+  const lines = value.split('\n');
+
+  let maximumColumnName = 0,
+    MaximumColumnType = 0;
+  for (const line of lines) {
+    const [columnName, columnType] = line.split(' ');
+    maximumColumnName = Math.max(maximumColumnName, columnName.length);
+    MaximumColumnType = Math.max(MaximumColumnType, (columnType ?? '').length);
+  }
+
+  return lines
+    .map(line => line.split(' '))
+    .map(([columnName, columnType, ...rest]) =>
+      [
+        columnName.padEnd(maximumColumnName + 1),
+        columnType ? columnType.padEnd(MaximumColumnType + 1) : '',
+        ...rest.map(v => v.trim()),
+      ].join(' '),
     )
     .join('\n');
 };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6,7 +6,7 @@ import { column } from './column';
 import { del, nonNullable } from '../types/utils';
 import { dedent } from './lib/dedent';
 import { Column, validate } from '../types';
-import { align } from './align';
+import { alignFields, alignKv } from './align';
 
 type CodegenResult = { schema: string; time: number; output: string };
 
@@ -28,14 +28,14 @@ export default (config: Types.Config): CodegenResult => {
   const schema = dedent(
     [
       header('datasource'),
-      block('datasource db', align(kv(datasource), '=')),
+      block('datasource db', alignKv(kv(datasource))),
 
       group(
         header('generators'),
         generators.map(generator =>
           block(
             `generator ${generator.name}`,
-            align(kv(del(generator, 'name')), '='),
+            alignKv(kv(del(generator, 'name'))),
           ),
         ),
       ),
@@ -55,7 +55,7 @@ export default (config: Types.Config): CodegenResult => {
         models.map(model =>
           block(
             `model ${model.name}`,
-            align(model.columns.map(column).join('\n')),
+            alignFields(model.columns.map(column).join('\n')),
           ),
         ),
       ),

--- a/src/codegen/modifiers.ts
+++ b/src/codegen/modifiers.ts
@@ -12,7 +12,7 @@ export const modifier = <T extends Type>(
       return `@default(${
         type == 'Enum' ? modifier.value : transform(modifier.value)
       })`;
-    case 'index':
+    case 'id':
       return `@id`;
     case 'unique':
       return '@unique';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,6 +2131,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
 pretty-format@^27.0.0, pretty-format@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"


### PR DESCRIPTION
With this PR I split the `align` helper into:
- `alignKv` splits lines with the `=` delimiter and treats the lines as a key value.
- `alignFields` split lines with the space delimiter and format the lines in a similar way to what `prisma format` command do.

Example output:
```    
    model User {
        id          Int       @id @default(autoincrement()) @map("_id") @db.Value('foo')
        email       String    @unique
        name        String?  
        height      Float     @default(1.8)
        role        Role      @default(USER)
        posts       Post[]   
        bestPostId  Int      
        bestPost    Post      @relation(fields: [bestPostId], references: [id])
        createdAt   DateTime  @default(now())
        updatedAt   DateTime  @updatedAt
    }
```