### PR TITLE
fix: crash when previewFeatures are not available in generator

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -46,7 +46,7 @@ export const validate = (config: Config): Config => {
   if (config.datasource.referentialIntegrity) {
     if (
       !config.generators.some(g =>
-        g.previewFeatures.includes('referentialIntegrity'),
+        g.previewFeatures?.includes('referentialIntegrity'),
       )
     )
       throw new Error(
@@ -58,8 +58,8 @@ export const validate = (config: Config): Config => {
     if (
       config.generators.some(
         g =>
-          g.previewFeatures.includes('fullTextSearch') &&
-          !g.previewFeatures.includes('fullTextIndex'),
+          g.previewFeatures?.includes('fullTextSearch') &&
+          !g.previewFeatures?.includes('fullTextIndex'),
       )
     )
       throw new Error(


### PR DESCRIPTION
Some generators don't have `previewFeatures` (such as the [zod-prisma](https://github.com/CarterGrimmeisen/zod-prisma) one). In this case refract seems to fail with:

```
node_modules/@cwqt/refract/dist/types/config.js:15
        if (config.generators.some(g => g.previewFeatures.includes('fullTextSearch') &&
                              ^
TypeError: Cannot read properties of undefined (reading 'includes')
```

This PR simply optionally chains the access so that this error doesn't occur anymore.

To manually test this I've simply commented out [line 29](https://github.com/cwqt/refract/blob/main/src/__tests__/index.spec.ts#L29) and [line 41](https://github.com/cwqt/refract/blob/main/src/__tests__/index.spec.ts#L41) and ran the tests with and without the fix.