### PR TITLE
Adding the ability to save comments in AST

### DIFF
--- a/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -49,6 +49,8 @@ model User {
 	role             Role       @default(USER)
 	// Relations are cool
 	posts            Post[]     @relation(\\"WrittenPosts\\")
+	///              Archived   posts comment
+	archivedPosts    Post[]
 	pinned           Post?      @relation(\\"PinnedPost\\")
 	createdAt        DateTime   @default(now())
 	updatedAt        DateTime   @updatedAt @db.Date(6)

--- a/src/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/__tests__/__snapshots__/index.spec.ts.snap
@@ -21,23 +21,30 @@ generator client {
 
 // enums ---------------------------------------------------------------------------
 
-// This is the Role Enum
+/// This is the Role Enum
 enum Role {
 	// This is the admin role
 	ADMIN @map(\\"admin\\")
 	USER @map(\\"user\\")
-	// This is the owner role
+	/// This is the owner role
 	OWNER @map(\\"owner\\")
+}
+
+// This is the Status Enum
+enum Status {
+	// This is the new status
+	NEW @map(\\"new\\")
+	PUBLISHED @map(\\"published\\")
 }
 
 // models --------------------------------------------------------------------------
 
-// This is the User model
+/// This is the User model
 model User {
 	id               Int        @id @default(autoincrement()) @map(\\"_id\\") @db.Value('foo')
 	email            String     @unique @db.VarChar(4)
 	name             String?
-	// The user model
+	///              The        user model
 	height           Float      @default(1.8)
 	role             Role       @default(USER)
 	// Relations are cool
@@ -52,6 +59,7 @@ model Post {
 	id                 Int       @id @default(autoincrement()) @db.UnsignedSmallInt
 	published          Boolean   @default(false)
 	title              String
+	status             Status    @default(NEW)
 	authorId           Int?
 	author             User?     @relation(\\"WrittenPosts\\", fields: [authorId], references: [id], onUpdate: Restrict, onDelete: SetNull)
 	pinnedById         Int?

--- a/src/__tests__/schema.ts
+++ b/src/__tests__/schema.ts
@@ -27,20 +27,29 @@ import {
   Unique,
   Unsupported,
   UpdatedAt,
+  Comment,
+  AstComment,
 } from '..';
 
 // roughly from: https://www.prisma.io/docs/concepts/components/prisma-schema#example
 
 const Role = Enum(
   'Role',
-  'This is the Role Enum',
-  Key('ADMIN', Map('admin'), 'This is the admin role'),
+  AstComment('This is the Role Enum'),
+  Key('ADMIN', Map('admin'), Comment('This is the admin role')),
   Key('USER', Map('user')),
-  Key('OWNER', Map('owner'), 'This is the owner role'),
+  Key('OWNER', Map('owner'), AstComment('This is the owner role')),
+);
+
+const Status = Enum(
+  'Status',
+  'This is the Status Enum',
+  Key('NEW', Map('new'), 'This is the new status'),
+  Key('PUBLISHED', Map('published')),
 );
 
 const Post = Model('Post');
-const User = Model('User', 'This is the User model');
+const User = Model('User', AstComment('This is the User model'));
 const Star = Model('Star');
 
 // prettier-ignore
@@ -54,7 +63,7 @@ User
   .Field('id',          Int(Id, Default('autoincrement()'), Map('_id'), Raw("@db.Value('foo')")))
   .Field('email',       String(Unique, db.VarChar(4)))
   .Field('name',        String(Nullable))
-  .Field('height',      Float(Default(1.80)), "The user model")
+  .Field('height',      Float(Default(1.80)), AstComment("The user model"))
   .Field('role',        Role('USER', Nullable))
   .Relation('posts',    OneToMany(Post, "WrittenPosts"), "Relations are cool")
   .Relation('pinned',   OneToOne(Post, "PinnedPost", Nullable))
@@ -65,6 +74,7 @@ Post
   .Field('id',          Int(Id, Default('autoincrement()'), db.UnsignedSmallInt))
   .Field('published',   Boolean(Default(false) ))
   .Field('title',       String(Limit(255)))
+  .Field('status',      Status('NEW'))
   .Relation(
     'author',
     ManyToOne(
@@ -101,11 +111,11 @@ Star
   .Mixin(Timestamps)
   .Field("location",    Unsupported("polygon", Nullable))
   .Block(Compound.Unique(["A", "B"], Map("_AB_unique")))
-  .Block(Compound.Index(["wow"], Map("_B_index")), "Block level comments?")
+  .Block(Compound.Index(["wow"], Map("_B_index")), Comment("Block level comments?"))
   .Block(Compound.Map("Group"))
   .Block(Compound.Fulltext(["location", "decimal"]))
 
-export default [Role, User, Post, Star];
+export default [Role, Status, User, Post, Star];
 
 // let x = OneToOne(Post, 'WrittenPosts', Fields('wow'), References('wee'));
 // let a = OneToOne(Post, Fields('bestPostId'), References('id')); // good

--- a/src/__tests__/schema.ts
+++ b/src/__tests__/schema.ts
@@ -66,6 +66,7 @@ User
   .Field('height',      Float(Default(1.80)), AstComment("The user model"))
   .Field('role',        Role('USER', Nullable))
   .Relation('posts',    OneToMany(Post, "WrittenPosts"), "Relations are cool")
+  .Relation('archivedPosts',    OneToMany(Post), AstComment('Archived posts comment'))
   .Relation('pinned',   OneToOne(Post, "PinnedPost", Nullable))
   .Mixin(Timestamps);
 

--- a/src/codegen/column.ts
+++ b/src/codegen/column.ts
@@ -8,6 +8,8 @@ export const column = (column: Types.Column): string => {
   if (Types.Fields.isCompound(column)) return compound(column);
   if (Types.Fields.isComment(column))
     return `\t// ${column.modifiers[0].value}`;
+  if (Types.Fields.isAstComment(column))
+    return `\t/// ${column.modifiers[0].value}`;
   if (Types.Fields.isRaw(column)) return `\t${column.modifiers[0].value}`;
   if (Types.Fields.isEnum(column)) return enumeration(column);
   if (Types.Fields.isEnumKey(column)) return enumKey(column);

--- a/src/codegen/model.ts
+++ b/src/codegen/model.ts
@@ -8,9 +8,6 @@ import { column } from './column';
 export const model = (model: Types.Blocks.Model): string => {
   const [comments, columns] = extractComments(model.columns);
 
-  console.log('>>> columns im model', columns.filter((col) => col?.name === 'comment').map((c) => c.modifiers));
-  columns.filter((col) => col?.name === 'archivedPosts').map((col) => console.log('archivedPosts', col?.modifiers))
-
   return [
     comments,
     block(`model ${model.name}`, alignFields(columns.map(column).join('\n'))),

--- a/src/codegen/model.ts
+++ b/src/codegen/model.ts
@@ -22,22 +22,22 @@ export const extractComments = (
   return [
     // All comment rows for a model are placed outside the model block def
     columns
-      .filter(c => c.type == 'Comment')
-      .map(c => `// ${c.modifiers[0].value}`)
+      .filter(c => c.type == 'Comment' || c.type == 'AstComment')
+      .map(c => c.type == 'Comment' ? `// ${c.modifiers[0].value}` : `/// ${c.modifiers[0].value}`)
       .join('\n'),
 
     columns
-      // Remove Comment rows to prevent re-insertion
-      .filter(c => c.type !== 'Comment')
+      // Remove Comment and AstComment rows to prevent re-insertion
+      .filter(c => c.type !== 'Comment' && c.type !== 'AstComment')
       // Shift all comment modifiers to be on their own row as a Comment column
       .reduce(
         (cols, column) => [
           ...cols,
           ...column.modifiers
-            .filter(c => c.type == 'comment')
+            .filter(c => c.type == 'Comment' || c.type == 'AstComment')
             .map(c => ({
               name: 'comment',
-              type: 'Comment',
+              type: c.type,
               modifiers: [c],
             })),
           column,

--- a/src/codegen/model.ts
+++ b/src/codegen/model.ts
@@ -1,3 +1,4 @@
+import { CommentsTypes } from '../public/fields/comments';
 import * as Types from '../types';
 import { nonNullable } from '../types/utils';
 import { alignFields } from './align';
@@ -6,6 +7,9 @@ import { column } from './column';
 
 export const model = (model: Types.Blocks.Model): string => {
   const [comments, columns] = extractComments(model.columns);
+
+  console.log('>>> columns im model', columns.filter((col) => col?.name === 'comment').map((c) => c.modifiers));
+  columns.filter((col) => col?.name === 'archivedPosts').map((col) => console.log('archivedPosts', col?.modifiers))
 
   return [
     comments,
@@ -19,28 +23,35 @@ export const model = (model: Types.Blocks.Model): string => {
 export const extractComments = (
   columns: Types.Column<any>[],
 ): [outside: string, columns: Types.Column[]] => {
+  const isUsualComment = (c: Types.Column<any> | Types.Modifier<any>) => c?.type === CommentsTypes.Comment;
+  const isAstComment = (c: Types.Column<any> | Types.Modifier<any>) => c?.type === CommentsTypes.AstComment;
+  const isComment = (c: Types.Column<any> | Types.Modifier<any>) => isUsualComment(c) || isAstComment(c);
+
   return [
     // All comment rows for a model are placed outside the model block def
     columns
-      .filter(c => c.type == 'Comment' || c.type == 'AstComment')
-      .map(c => c.type == 'Comment' ? `// ${c.modifiers[0].value}` : `/// ${c.modifiers[0].value}`)
+      .filter(c => isComment(c))
+      .map(c => isAstComment(c) ? `/// ${c.modifiers[0].value}` : `// ${c.modifiers[0].value}`)
       .join('\n'),
 
     columns
       // Remove Comment and AstComment rows to prevent re-insertion
-      .filter(c => c.type !== 'Comment' && c.type !== 'AstComment')
+      .filter(c => !isComment(c))
       // Shift all comment modifiers to be on their own row as a Comment column
       .reduce(
         (cols, column) => [
           ...cols,
           ...column.modifiers
-            .filter(c => c.type == 'Comment' || c.type == 'AstComment')
+            .filter(c => isComment(c))
             .map(c => ({
               name: 'comment',
               type: c.type,
               modifiers: [c],
             })),
-          column,
+          {
+            ...column,
+            modifiers: column.modifiers.filter(c => !isComment(c)),
+          },
         ],
         [],
       ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from './public/fields/scalars';
 export * from './public/fields/enums';
 export * from './public/fields/relations';
 export * from './public/fields/unsupported';
+export * from './public/fields/comments';
 export * as Compound from './public/fields/compounds';
 export * as Types from './types';
 export * from './public/db';

--- a/src/public/fields/comments.ts
+++ b/src/public/fields/comments.ts
@@ -1,0 +1,18 @@
+export enum CommentsTypes {
+  Comment = 'Comment',
+  AstComment = 'AstComment'
+}
+
+const comment = (type: CommentsTypes) => (value: string): CommentType => ({
+  type,
+  value,
+});
+
+export const Comment = comment(CommentsTypes.Comment);
+
+export const AstComment = comment(CommentsTypes.AstComment);
+
+export type CommentType = {
+  type: CommentsTypes
+  value: string;
+}

--- a/src/public/model.ts
+++ b/src/public/model.ts
@@ -80,9 +80,6 @@ export class $Model implements Types.Blocks.Model, Model {
       type.modifiers.push({ type: comment.type, value: comment.value } as any);
     }
 
-    console.log('>>> Relation', type);
-    
-
     // Fields('column', Int())
     const fields = type.modifiers.find(m => m.type == 'fields');
     if (isScalar(fields?.value?.[1])) {

--- a/src/public/model.ts
+++ b/src/public/model.ts
@@ -1,5 +1,6 @@
 import * as Types from '../types';
 import { isScalar } from '../types/fields';
+import { CommentType, Comment } from './fields/comments';
 
 // Don't really care about the `as unknown` casts too much
 // as long as the public interface is type-safe....
@@ -11,20 +12,20 @@ type Model = {
   Relation: <T extends Types.Fields.Relation>(
     name: string,
     type: Types.Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) => Model;
   Field: <T extends Types.Fields.Scalar | 'Enum' | 'Unsupported'>(
     name: string,
     type: Types.Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) => Model;
   Block: <T extends Types.Fields.Compound>(
     type: Types.Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) => Model;
 } & Types.Blocks.Model;
 
-export const Model = (name: string, comment?: string): Model =>
+export const Model = (name: string, comment?: CommentType | string): Model =>
   new $Model(name, comment);
 
 export class $Model implements Types.Blocks.Model, Model {
@@ -32,14 +33,17 @@ export class $Model implements Types.Blocks.Model, Model {
   type: 'model' = 'model';
   columns: Types.Column<Types.Type>[] = [];
 
-  constructor(name: string, comment?: string) {
+  constructor(name: string, comment?: CommentType | string) {
     this.name = name;
 
     if (comment) {
+      if (typeof comment === 'string') {
+        comment = Comment(comment);
+      }
       this.columns.push({
         name: 'comment',
-        type: 'Comment' as const,
-        modifiers: [{ type: 'value', value: comment }],
+        type: comment.type as string,
+        modifiers: [{ type: 'value', value: comment.value }],
       } as Types.Column<Types.Type>);
     }
   }
@@ -67,10 +71,14 @@ export class $Model implements Types.Blocks.Model, Model {
   Relation<T extends Types.Fields.Relation>(
     name: string,
     type: Types.Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) {
-    if (comment)
-      type.modifiers.push({ type: 'comment', value: comment } as any);
+    if (comment) {
+      if (typeof comment === 'string') {
+        comment = Comment(comment);
+      }
+      type.modifiers.push({ type: comment.type, value: comment.value } as any);
+    }
 
     // Fields('column', Int())
     const fields = type.modifiers.find(m => m.type == 'fields');
@@ -87,10 +95,14 @@ export class $Model implements Types.Blocks.Model, Model {
   Field<T extends Types.Fields.Scalar | 'Enum' | 'Unsupported'>(
     name: string,
     type: Types.Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) {
-    if (comment)
-      type.modifiers.push({ type: 'comment', value: comment } as any);
+    if (comment) {
+      if (typeof comment === 'string') {
+        comment = Comment(comment);
+      }
+      type.modifiers.push({ type: comment.type, value: comment.value } as any);
+    }
 
     this.columns.push({ name, ...type } as unknown as Types.Column<Types.Type>);
     return this;
@@ -98,10 +110,14 @@ export class $Model implements Types.Blocks.Model, Model {
 
   Block<T extends Types.Fields.Compound>(
     type: Types.Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) {
-    if (comment)
-      type.modifiers.push({ type: 'comment', value: comment } as any);
+    if (comment) {
+      if (typeof comment === 'string') {
+        comment = Comment(comment);
+      }
+      type.modifiers.push({ type: comment.type, value: comment.value } as any);
+    }
 
     this.columns.push(type as unknown as Types.Column<Types.Type>);
     return this;

--- a/src/public/model.ts
+++ b/src/public/model.ts
@@ -80,6 +80,9 @@ export class $Model implements Types.Blocks.Model, Model {
       type.modifiers.push({ type: comment.type, value: comment.value } as any);
     }
 
+    console.log('>>> Relation', type);
+    
+
     // Fields('column', Int())
     const fields = type.modifiers.find(m => m.type == 'fields');
     if (isScalar(fields?.value?.[1])) {

--- a/src/types/fields.ts
+++ b/src/types/fields.ts
@@ -49,6 +49,10 @@ export function isComment(column: TopColumn): column is Column<'Comment'> {
   return column.type == 'Comment';
 }
 
+export function isAstComment(column: TopColumn): column is Column<'AstComment'> {
+  return column.type == 'AstComment';
+}
+
 export function isCompound(column: TopColumn): column is Column<Compound> {
   return column.type.startsWith('@@');
 }

--- a/src/types/mixins.ts
+++ b/src/types/mixins.ts
@@ -1,15 +1,16 @@
 import { Fields, Type } from '.';
+import { CommentType } from '../public/fields/comments';
 import { Column } from './columns';
 
 export type Mixin = {
   Field: <T extends Fields.Scalar | 'Enum' | 'Unsupported'>(
     name: string,
     type: Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) => Mixin;
   Block: <T extends Fields.Compound>(
     type: Fields.Field<T>,
-    comment?: string,
+    comment?: CommentType | string,
   ) => Mixin;
   columns: Column<Type>[];
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import { Types } from '..';
+import { CommentType, Types } from '..';
 import { JsonValue } from '../codegen/lib/json';
 import { Model } from './blocks';
 import { ReferentialAction, Scalar } from './fields';
@@ -51,7 +51,7 @@ export type Scalars = Append<
     ignore?: true;
     raw?: string;
     array?: true;
-    comment?: string;
+    comment?: CommentType | string;
   }
 >;
 
@@ -61,7 +61,7 @@ export type Enums = {
     nullable?: true;
     default?: string;
     ignore?: true;
-    comment?: string;
+    comment?: CommentType | string;
 
     // Enum of which this is from
     enum: string;
@@ -69,7 +69,7 @@ export type Enums = {
   // An entry in the enum, e.g. Enum("name", Key("Id", Map("_id")))
   EnumKey: {
     map?: string;
-    comment?: string;
+    comment?: CommentType | string;
   };
 };
 
@@ -96,7 +96,7 @@ export type Relations = Append<
       nullable?: true;
     };
   },
-  { name?: string; model: Model; comment?: string }
+  { name?: string; model: Model; comment?: CommentType | string }
 >;
 
 export type Compounds = Append<
@@ -108,14 +108,15 @@ export type Compounds = Append<
     ['@@map']: {};
     ['@@fulltext']: {};
   },
-  { values: string[]; comment?: string }
+  { values: string[]; comment?: CommentType | string }
 >;
 
 export type TypeData = MergeDbModifiers<Scalars> &
   Compounds &
   Enums &
   Relations & {
-    Comment: { value: string };
+    Comment: CommentType | string;
+    AstComment: CommentType | string;
     Raw: { value: string };
     Unsupported: { unsupported: string; nullable?: true };
   };


### PR DESCRIPTION
According to the official Prisma [documentation](https://www.prisma.io/docs/concepts/components/prisma-schema#comments), several types of comments are supported: 
- the standard `//`, which are not saved in AST 
- and those that are saved in AST `///`

I've added an implementation of both types of comments with backwards support for comments with string passing. Please take a look at my PR, if anything needs to be fixed, please let me know.