### PR TITLE
fix: refined generator type to allow for custom fields

### DIFF
--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -33,6 +33,7 @@ export type Generator = {
   previewFeatures?: PreviewFeatures[];
   engineType?: 'library' | 'binary';
   binaryTargets?: string[]; // TODO: enum
+  [key: string]: any;
 };
 
 export type Config = {


### PR DESCRIPTION
Refined the type for generators, so you can add custom fields that some third-party generators may require.